### PR TITLE
Clarifies single line for Python 2 and 3

### DIFF
--- a/python3_user_transition_guide.rst
+++ b/python3_user_transition_guide.rst
@@ -5,16 +5,17 @@ Switching to Python 3 can seem like a daunting task, but this guide will
 provide some tips and resources to help make it more straightforward.
 
 
-Changes you can make today to make the transition easier
---------------------------------------------------------
-
+Writing Python 3 compatible code
+---------------------------------------------
 Any new code you write can easily be Python 3 compatible! This is the first step
-you can take towards switching. Thankfully, the most disruptive changes to the
-language have been back-ported to Python 2 so you can ensure that, when writing
+you can take towards switching. For scientific scripts, being Python 3 combatible
+tends to imply Python 2 compatability.
+
+Thankfully, the most disruptive changes to the
+language have been back-ported to Python 2 so you can ensure that when writing
 new code that you intend to execute with Python 2, it will be executable in
 Python 3 once you switch. To use these back-ported changes, you must import
-certain utilities from the built-in ```__future__``
-<https://docs.python.org/2/library/__future__.html>`_ package. It is generally
+certain utilities from the built-in ``__future__`` package. It is generally
 recommended that, if you are still writing Python 2 compatible code, you should
 import the following four modules in any code you write::
 

--- a/python3_user_transition_guide.rst
+++ b/python3_user_transition_guide.rst
@@ -4,19 +4,6 @@ Python 3 transition guide
 Switching to Python 3 can seem like a daunting task, but this guide will
 provide some tips and resources to help make it more straightforward.
 
-Changes for vanilla Python to support both Python 2 and 3
----------------------------------------------------------
-Vanilla Python code (i.e., typical scientific code)
-does not need much modification to run under *both* Python 2 and Python 3.
-
-For these scripts, including the line below at the top
-of the script makes the script run under both Python 2 and Python 3.
-
-.. code-block:: python
-
-    from __future__ import print_function, division, absolute_import
-    
-The next section provides an explanation of what this provides.
 
 Changes you can make today to make the transition easier
 --------------------------------------------------------

--- a/python3_user_transition_guide.rst
+++ b/python3_user_transition_guide.rst
@@ -4,6 +4,20 @@ Python 3 transition guide
 Switching to Python 3 can seem like a daunting task, but this guide will
 provide some tips and resources to help make it more straightforward.
 
+Changes for vanilla Python to support both Python 2 and 3
+---------------------------------------------------------
+Vanilla Python code (i.e., typical scientific code)
+does not need much modification to run under *both* Python 2 and Python 3.
+
+For these scripts, including the line below at the top
+of the script makes the script run under both Python 2 and Python 3.
+
+.. code-block:: python
+
+    from __future__ import print_function, division, absolute_import
+    
+The next section provides an explanation of what this provides.
+
 Changes you can make today to make the transition easier
 --------------------------------------------------------
 

--- a/python3_user_transition_guide.rst
+++ b/python3_user_transition_guide.rst
@@ -1,12 +1,5 @@
-Python 3 transition guide
-=========================
-
-Switching to Python 3 can seem like a daunting task, but this guide will
-provide some tips and resources to help make it more straightforward.
-
-
 Writing Python 3 compatible code
----------------------------------------------
+================================
 Any new code you write can easily be Python 3 compatible! This is the first step
 you can take towards switching. For scientific scripts, being Python 3 combatible
 tends to imply Python 2 compatability.


### PR DESCRIPTION
Added a section to the transition guide that clarified a script can include one line to run under both Python 2 and Python 3. IMHO, this helps with the impression the "transition" to Python 3 is not a huge step for scientists.
